### PR TITLE
feat(.github): automatically create releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
 
 jobs:
   build:
@@ -23,20 +21,33 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: |
+      - id: package
+        run: |
           make tar
           for i in build/out/*.tar.gz; do
             echo ${i}
             tar -tvf ${i}
           done
+          echo "version=$(make get-version)" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         with:
           name: coredns
           path: build/out
           retention-days: ${{ github.event_name == 'pull_request' && 1 || 30 }}
-      - name: release
+      - id: existing-tags
+        name: Get existing tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "tags=$(gh api repos/{owner}/{repo}/releases | jq -c 'map(.tag_name)')" >> $GITHUB_OUTPUT
+      - name: Create release
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          || (github.event_name == 'push'
+            && !contains(fromJSON(steps.existing-tags.outputs.tags), steps.package.outputs.version)
+          )
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
+          tag_name: ${{ steps.package.outputs.version }}
           files: |
             build/out/*

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,6 @@ clean/build/out:
 
 .PHONY: clean
 clean: clean/build clean/src
+
+get-version:
+	@echo $(COREDNS_VERSION)

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ In practice this is all done in a github action.
 
 ## Releasing a new version
 
-Once everything is updated just push a tag and github actions will create a release with the binaries.
-We usually just use the coredns tag. So for example: `git tag v1.10.1; git push origin --tag`
+If the version in `main` changes, a build of the binaries of that version is triggered and a release is created if one does not yet exist.
+You can also manually trigger the workflow on a given commit, which also allows a release to be recreated.


### PR DESCRIPTION
This PR adds an automatic build + release when the version changes on `main` and a release doesn't exist. It eliminates needing to name and push a tag to trigger a workflow in favor of triggering via the Github UI and recreates releases when manually triggered.
It does not allow the tag to differ from the coredns version in `go.mod`, but it's not clear this is ever needed and is more likely to only lead to a mistake. Otherwise it can be added as a `workflow_dispatch` input.

See [a push](https://github.com/michaelbeaumont/coredns-builds/actions/runs/4480421342/jobs/7875704358) and [a triggered job](https://github.com/michaelbeaumont/coredns-builds/actions/runs/4480435837)