### PR TITLE
ci(.github): add lifecycle job

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -1,0 +1,14 @@
+name: project-lifecycle
+on:
+  schedule:
+    - cron: 0 8 * * *
+  workflow_dispatch:
+  issues:
+    types:
+      - reopened
+      - opened
+      - labeled
+
+jobs:
+  lifecycle:
+    uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@main


### PR DESCRIPTION
Required to make things synced automatically with standard OSS info