### PR TITLE
chore(deps): update to go v1.21

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: "~1.20.2"
+          go-version-file: go.mod
       - uses: actions/cache@v3
         with:
           path: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuma/coredns-builds
 
-go 1.20
+go 1.21
 
 require (
 	github.com/coredns/alternate v0.2.9


### PR DESCRIPTION
Just to stop build errors, we can potentially update to v1.22 in a separate PR